### PR TITLE
Improve WireGuard launcher

### DIFF
--- a/src/CustomWireGuardLauncher/App.xaml
+++ b/src/CustomWireGuardLauncher/App.xaml
@@ -1,0 +1,6 @@
+<Application x:Class="CustomWireGuardLauncher.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources/>
+</Application>

--- a/src/CustomWireGuardLauncher/App.xaml.cs
+++ b/src/CustomWireGuardLauncher/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace CustomWireGuardLauncher;
+
+public partial class App : Application
+{
+}

--- a/src/CustomWireGuardLauncher/CustomWireGuardLauncher.csproj
+++ b/src/CustomWireGuardLauncher/CustomWireGuardLauncher.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ServiceProcess.ServiceController" />
+  </ItemGroup>
+</Project>

--- a/src/CustomWireGuardLauncher/MainWindow.xaml
+++ b/src/CustomWireGuardLauncher/MainWindow.xaml
@@ -1,0 +1,12 @@
+<Window x:Class="CustomWireGuardLauncher.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="WireGuard Launcher" Height="150" Width="400">
+    <StackPanel Margin="10">
+        <ComboBox x:Name="ConfigBox" MinWidth="200" Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+            <Button Content="Connect" Width="80" Margin="0,0,10,0" Click="Connect_Click"/>
+            <Button Content="Disconnect" Width="80" Click="Disconnect_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/CustomWireGuardLauncher/MainWindow.xaml.cs
+++ b/src/CustomWireGuardLauncher/MainWindow.xaml.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.ServiceProcess;
+using System.Threading.Tasks;
+using System.IO;
+using System.Linq;
+using System.Windows;
+
+namespace CustomWireGuardLauncher;
+
+public partial class MainWindow : Window
+{
+    private readonly List<string> _configFiles = new();
+    private readonly string _configDir;
+    private const string ServiceName = "ProtonVPN WireGuard";
+    private const string ConfigFilePath = "C:\\ProgramData\\ProtonVPN\\WireGuard\\ProtonVPN.conf";
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        _configDir = Path.Combine(AppContext.BaseDirectory, "wireguard-configs");
+        LoadConfigs();
+    }
+
+    private void LoadConfigs()
+    {
+        if (!Directory.Exists(_configDir))
+        {
+            Directory.CreateDirectory(_configDir);
+        }
+        _configFiles.Clear();
+        _configFiles.AddRange(Directory.GetFiles(_configDir, "*.conf"));
+        ConfigBox.ItemsSource = _configFiles.Select(Path.GetFileNameWithoutExtension);
+        if (ConfigBox.Items.Count > 0)
+        {
+            ConfigBox.SelectedIndex = 0;
+        }
+    }
+
+    private async void Connect_Click(object sender, RoutedEventArgs e)
+    {
+        if (ConfigBox.SelectedIndex < 0) return;
+        string configName = _configFiles[ConfigBox.SelectedIndex];
+        try
+        {
+            string configText = await FetchConfigAsync();
+            Directory.CreateDirectory(Path.GetDirectoryName(ConfigFilePath)!);
+            await File.WriteAllTextAsync(ConfigFilePath, configText);
+            StartWireGuard(ConfigFilePath);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to connect: {ex.Message}");
+        }
+    }
+
+    private void Disconnect_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            StopWireGuard();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to disconnect: {ex.Message}");
+        }
+    }
+
+    private static void StartWireGuard(string configPath)
+    {
+        ServiceController sc = new(ServiceName);
+        if (sc.Status != ServiceControllerStatus.Running)
+        {
+            sc.Start();
+        }
+    }
+
+    private static void StopWireGuard()
+    {
+        ServiceController sc = new(ServiceName);
+        if (sc.Status != ServiceControllerStatus.Stopped)
+        {
+            sc.Stop();
+        }
+    }
+
+    private static async Task<string> FetchConfigAsync()
+    {
+        using HttpClient client = new();
+        return await client.GetStringAsync("https://www.futuresoftware.ae/APITest/WgApi");
+    }
+}

--- a/src/CustomWireGuardLauncher/Properties/AssemblyInfo.cs
+++ b/src/CustomWireGuardLauncher/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Windows;
+
+[assembly:ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]


### PR DESCRIPTION
## Summary
- update `CustomWireGuardLauncher` to fetch config from a web API
- use `System.ServiceProcess.ServiceController` to start/stop the ProtonVPN WireGuard service

## Testing
- `dotnet build src/CustomWireGuardLauncher/CustomWireGuardLauncher.csproj -c Release -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build ProtonVpn.sln -c Release -p:EnableWindowsTargeting=true` *(fails: Windows desktop build tools missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855bfdb71c8832a95674081c4e26e5d